### PR TITLE
feat: add log injection for client.say()

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -17,7 +17,7 @@ class Client extends IrcClient {
 			dialect: 'sqlite',
 			storage: db_file || 'unknown.db',
 			operatorsAliases: false,
-			logging: process.env.NODE_ENV != "production"
+			logging: process.env.NODE_ENV != "production" ? console.log : false
 		});
 	}
 }

--- a/src/plugins/logging/index.ts
+++ b/src/plugins/logging/index.ts
@@ -23,10 +23,36 @@ function LoggingHandler(command, event, client, next) {
 	next();
 }
 
+/** 
+	as we're not able to rely on all/any irc servers to echo our msg,
+	we'll inject a utility function on the client class that lets other
+	plugins log their messages transparently.
+	
+	TODO: maybe find a less "hacky" way?
+*/
+function LogInject(client) {
+	const oldSay = client.say;
+	client.say = function injectedSay(dest, message) {
+		const isChannel = client.network.isChannelName(dest);
+		client.db.models.logs.create({
+			event: 'message',
+			nick: client.user.nick,
+			ident: client.user.username,
+			host: client.user.host,
+			target: isChannel ? null : dest,
+			channel: isChannel ? dest : null,
+			message: message,
+		}).catch(error => console.error(Chalk.red(error)));
+		return oldSay.apply(client, arguments);
+	}
+}
+
 export function Logging() {
 	return function LogMiddleWare(client, _raw_events, parsed_events) {
 		client.db.define("logs", Log);
 		client.db.sync();
+
+		LogInject(client);
 
 		parsed_events.use(LoggingHandler);
 	}


### PR DESCRIPTION
Add logging for bot's own lines by injecting client.say() method with logging function so it works transparently throughout the code base.